### PR TITLE
Enabled external customization of variables in configure.ac

### DIFF
--- a/.github/workflows/build_helper.sh
+++ b/.github/workflows/build_helper.sh
@@ -352,15 +352,15 @@ fi
 # Set variables for packaging
 #
 if [ "X${OPT_BUILD_NUMBER}" != "X" ]; then
-	BUILD_NUMBER=${BUILD_NUMBER}
+	BUILD_NUMBER="${OPT_BUILD_NUMBER}"
 else
 	BUILD_NUMBER=1
 fi
 if [ "X${OPT_DEBEMAIL}" != "X" ]; then
-	export DEBEMAIL=${OPT_DEBEMAIL}
+	export DEBEMAIL="${OPT_DEBEMAIL}"
 fi
 if [ "X${OPT_DEBFULLNAME}" != "X" ]; then
-	export DEBFULLNAME=${OPT_DEBFULLNAME}
+	export DEBFULLNAME="${OPT_DEBFULLNAME}"
 fi
 
 #

--- a/.github/workflows/ostypevars.sh
+++ b/.github/workflows/ostypevars.sh
@@ -146,6 +146,11 @@ elif [ "X${CI_OSTYPE}" = "Xcentos:8" ] || [ "X${CI_OSTYPE}" = "Xcentos:centos8" 
 	PKG_EXT="rpm"
 	IS_OS_CENTOS=1
 
+	#
+	# Change mirrorlist
+	#
+	sed -i -e 's|^mirrorlist|#mirrorlist|g' -e 's|^#baseurl=http://mirror|baseurl=http://vault|g' /etc/yum.repos.d/CentOS-*repo
+
 	# [NOTE]
 	# Since it is difficult to install ShellCheck on CentOS8, it will not be installed.
 	#

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,7 @@ SUBDIRS = docs src buildutils test
 
 ACLOCAL_AMFLAGS = -I m4
 
-EXTRA_DIST = RELEASE_VERSION
+EXTRA_DIST = RELEASE_VERSION @CONFIGURECUSTOM@
 
 CLEANFILES = *.log src/libexec/common/VERSION
 
@@ -64,18 +64,30 @@ EXCLUDE_SHELLCHECK_FILE_OPT =	-not -name '*.sh' \
 								-not -name 'config.status' \
 								-not -name 'config.sub' \
 								-not -name 'configure' \
+								-not -name 'configure~' \
 								-not -name 'depcomp' \
 								-not -name 'install-sh' \
 								-not -name 'libtool' \
 								-not -name 'missing' \
-								-not -name 'test-driver'
+								-not -name 'test-driver' \
+								-not -name 'rules'
+
+SHELLCHECK_FILES = $(shell find . -type d $(EXCLUDE_SHELLCHECK_DIR_OPT) -o -executable -type f $(EXCLUDE_SHELLCHECK_FILE_OPT))
+SHELLCHECK_FILES_COMMON_SH = $(shell find . -type d $(EXCLUDE_SHELLCHECK_DIR_OPT) -o -type f -name '*.sh' | grep -v ostypevars.sh)
+SHELLCHECK_FILES_CUSTOM_SH = $(shell find . -type d $(EXCLUDE_SHELLCHECK_DIR_OPT) -o -type f -name '*.sh' | grep ostypevars.sh)
 
 shellcheck:
 	@if type shellcheck > /dev/null 2>&1; then \
 		echo "*** Check all files with ShellCheck"; \
-		$(SHELLCHECK_CMD) $(SHELLCHECK_OPT) $(SHELLCHECK_COMMON_IGN) $$(find . -type d $(EXCLUDE_SHELLCHECK_DIR_OPT) -o -executable -type f $(EXCLUDE_SHELLCHECK_FILE_OPT)) || exit 1; \
-		$(SHELLCHECK_CMD) $(SHELLCHECK_OPT) $(SHELLCHECK_COMMON_IGN) $$(find . -type d $(EXCLUDE_SHELLCHECK_DIR_OPT) -o -type f -name '*.sh' | grep -v ostypevars.sh) || exit 1; \
-		$(SHELLCHECK_CMD) $(SHELLCHECK_OPT) $(SHELLCHECK_CUSTOM_IGN) $$(find . -type d $(EXCLUDE_SHELLCHECK_DIR_OPT) -o -type f -name '*.sh' | grep ostypevars.sh) || exit 1; \
+		if [ -n "$(SHELLCHECK_FILES_ALL)" ]; then \
+			$(SHELLCHECK_CMD) $(SHELLCHECK_OPT) $(SHELLCHECK_COMMON_IGN) $(SHELLCHECK_FILES_ALL) || exit 1; \
+		fi; \
+		if [ -n "$(SHELLCHECK_FILES_COMMON_SH)" ]; then \
+			$(SHELLCHECK_CMD) $(SHELLCHECK_OPT) $(SHELLCHECK_COMMON_IGN) $(SHELLCHECK_FILES_COMMON_SH) || exit 1; \
+		fi; \
+		if [ -n "$(SHELLCHECK_FILES_CUSTOM_SH)" ]; then \
+			$(SHELLCHECK_CMD) $(SHELLCHECK_OPT) $(SHELLCHECK_CUSTOM_IGN) $(SHELLCHECK_FILES_CUSTOM_SH) || exit 1; \
+		fi; \
 		echo "   -> No error was detected."; \
 		echo ""; \
 	else \

--- a/autogen.sh
+++ b/autogen.sh
@@ -84,7 +84,7 @@ fi
 # Build configure and Makefile
 #
 echo "--- run aclocal ${FORCEPARAM}"
-aclocal ${FORCEPARAM}
+aclocal "${FORCEPARAM}"
 if [ $? -ne 0 ]; then
 	echo "ERROR: something error occurred in aclocal ${FORCEPARAM}"
 	exit 1

--- a/buildutils/make_rpm_changelog.sh
+++ b/buildutils/make_rpm_changelog.sh
@@ -82,6 +82,7 @@ DETAILS=""
 ALLLINES=""
 SET_FIRST_VERSION=0
 while read -r oneline; do
+	# shellcheck disable=SC2269
 	oneline="${oneline}"
 	if [ "X${oneline}" = "X" ]; then
 		continue
@@ -99,8 +100,7 @@ while read -r oneline; do
 		fi
 	else
 		TEST_CONTENTS=$(echo "${oneline}" | grep '^[-][-].*[ ][ ].*$')
-		PKG_RF2822=$(echo "${TEST_CONTENTS}" | grep -o '[ ][ ].*')
-		PKG_RF2822="${PKG_RF2822}"
+		PKG_RF2822="$(echo "${TEST_CONTENTS}" | grep -o '[ ][ ].*')"
 		PKG_COMMITTER=$(echo "${TEST_CONTENTS}" | grep -o '.*[ ][ ]' | sed 's/^[-][-][ ]//')
 		if [ "X${PKG_RF2822}" != "X" ] && [ "X${PKG_COMMITTER}" != "X" ]; then
 			INONEVER=0
@@ -125,7 +125,7 @@ done < "${CHANGELOG_FILE}"
 #
 # NOTE: echo command on ubuntu is print '-e', we need to cut it.
 #
-# shellcheck disable=SC2039
+# shellcheck disable=SC3037,SC2039
 echo -e "${ALLLINES}" | sed 's/^-e //g'
 
 exit 0

--- a/configure.ac
+++ b/configure.ac
@@ -33,14 +33,39 @@ AC_PROG_LN_S
 AC_PROG_MAKE_SET
 
 #
+# Load customizable variables
+#
+AC_CHECK_FILE([configure.custom],
+	[
+		configure_custom_file="configure.custom"
+		custom_git_domain="$(grep '^\s*GIT_DOMAIN\s*=' configure.custom | sed -e 's|^\s*GIT_DOMAIN\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_org="$(grep '^\s*GIT_ORG\s*=' configure.custom | sed -e 's|^\s*GIT_ORG\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_repo="$(grep '^\s*GIT_REPO\s*=' configure.custom | sed -e 's|^\s*GIT_REPO\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_endpoint="$(grep '^\s*GIT_EP_V3_REPO\s*=' configure.custom | sed -e 's|^\s*GIT_EP_V3_REPO\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_dev_email="$(grep '^\s*DEV_EMAIL\s*=' configure.custom | sed -e 's|^\s*DEV_EMAIL\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_dev_name="$(grep '^\s*DEB_NAME\s*=' configure.custom | sed -e 's|^\s*DEB_NAME\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+	],
+	[
+		configure_custom_file=""
+		custom_git_domain="github.com"
+		custom_git_org="yahoojapan"
+		custom_git_repo="k2hr3_cli"
+		custom_git_endpoint="https://api.github.com/repos/"
+		custom_dev_email="antpickax-support@mail.yahoo.co.jp"
+		custom_dev_name="K2HR3_DEVELOPER"
+	]
+)
+
+#
 # Symbols for buildutils
 #
-AC_SUBST([GIT_DOMAIN], "github.com")
-AC_SUBST([GIT_ORG], "yahoojapan")
-AC_SUBST([GIT_REPO], "k2hr3_cli")
-AC_SUBST([DEV_EMAIL], "`echo ${DEBEMAIL:-antpickax-support@mail.yahoo.co.jp}`")
-AC_SUBST([DEV_NAME], "`echo ${DEBFULLNAME:-K2HR3_DEVELOPER}`")
-
+AC_SUBST([CONFIGURECUSTOM], "${configure_custom_file}")
+AC_SUBST([GIT_DOMAIN], "${custom_git_domain}")
+AC_SUBST([GIT_ORG], "${custom_git_org}")
+AC_SUBST([GIT_REPO], "${custom_git_repo}")
+AC_SUBST([DEV_EMAIL], "$(echo ${DEBEMAIL:-"${custom_dev_email}"})")
+AC_SUBST([DEV_NAME], "$(echo ${DEBFULLNAME:-"${custom_dev_name}"})")
+#
 AC_SUBST([RPMCHANGELOG], "`$(pwd)/buildutils/make_rpm_changelog.sh $(pwd)/ChangeLog`")
 AC_SUBST([SHORTDESC], "`$(pwd)/buildutils/make_description.sh $(pwd)/docs/k2hr3.1 -short`")
 AC_SUBST([LONGDESC], "`$(pwd)/buildutils/make_description.sh $(pwd)/docs/k2hr3.1 -long`")

--- a/src/libexec/common/jsonparser.sh
+++ b/src/libexec/common/jsonparser.sh
@@ -752,7 +752,7 @@ jsonparser_parse_json_string()
 	# Case for Empty string
 	#
 	if [ "X${_JP_PAERSED_ESCAPED_JSON}" = "X" ]; then
-		touch ${_JP_PAERSED_FILE_TMP}
+		touch "${_JP_PAERSED_FILE_TMP}"
 		JP_PAERSED_FILE=${_JP_PAERSED_FILE_TMP}
 		return 0
 	fi

--- a/src/libexec/common/modelist.sh
+++ b/src/libexec/common/modelist.sh
@@ -76,7 +76,7 @@ _MODELIST_TMP=""
 for _MODELIST_ONEDIR in "${LIBEXECDIR}"/*; do
 	_MODELIST_ONEDIR=$(pecho -n "${_MODELIST_ONEDIR}" | sed "s#^${LIBEXECDIR}/##g")
 	case ${_MODELIST_ONEDIR} in
-		${COMMON_DIRNAME})
+		"${COMMON_DIRNAME}")
 			;;
 		*)
 			if [ "X${_MODELIST_TMP}" = "X" ]; then

--- a/src/libexec/common/strings.sh
+++ b/src/libexec/common/strings.sh
@@ -29,7 +29,7 @@
 # implemented.
 #
 _K2HR3_CLI_ECHO_EXP=1
-# shellcheck disable=SC2039
+# shellcheck disable=SC2039,SC3037
 _K2HR3_CLI_ECHO_TMP=$(echo -e "" | tr -d ' ')
 if [ "X${_K2HR3_CLI_ECHO_TMP}" = "X-e" ]; then
 	_K2HR3_CLI_ECHO_EXP=0
@@ -52,7 +52,7 @@ pecho()
 {
 	if [ "X$1" = "X-e" ]; then
 		if [ "${_K2HR3_CLI_ECHO_EXP}" -eq 1 ]; then
-			# shellcheck disable=SC2039
+			# shellcheck disable=SC2039,SC3037
 			echo -e "$*"
 		else
 			echo "$*"

--- a/test/test.sh
+++ b/test/test.sh
@@ -43,7 +43,7 @@ TEST_FILES=""
 for _TEST_FILE_TMP in "${TESTDIR}"/*; do
 	_TEST_FILE_TMP=$(echo "${_TEST_FILE_TMP}" | sed "s#^${TESTDIR}/##g")
 	case ${_TEST_FILE_TMP} in
-		${TESTMAINBIN})
+		"${TESTMAINBIN}")
 			;;
 		test_*.sh)
 			if [ "X${TEST_FILES}" = "X" ]; then

--- a/test/util_test.sh
+++ b/test/util_test.sh
@@ -84,7 +84,7 @@ K2HR3CLIBIN=${SRCDIR}/k2hr3
 #
 # Set Environments for test
 #
-export K2HR3CLI_LIBEXEC_DIR=${LIBEXECDIR}
+export K2HR3CLI_LIBEXEC_DIR="${LIBEXECDIR}"
 if [ "X${K2HR3CLI_REQUEST_FILE}" = "X" ]; then
 	export K2HR3CLI_REQUEST_FILE="${TESTDIR}/util_request.sh"
 fi


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
- Enabled to customize variables in configure.ac  
If the configure.custom file exists, it will be loaded.  
(currently unused but added to increase availability)
- Fixed CentOS 8 build failing.  
It was caused by changing the mirror, so I fixed it.
- Fixed shellcheck errors
